### PR TITLE
Use ltrace from tools module

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,7 +30,7 @@ class admintools {
   package { 'gawk':         ensure     => present, }
   package { 'psmisc':       ensure     => present, }
   package { 'binutils':     ensure     => present, }
-  package { 'ltrace':       ensure     => present, }
+  include tools::ltrace
   package { 'sysstat':      ensure     => present, }
 
   case $::osfamily {


### PR DESCRIPTION
This fixes potentially double definition and break execution:

```
Error: Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration:
 Package[ltrace] is already declared at (file: /etc/puppetlabs/code/environments/master/modules/admintools/manifests/init.pp, line: 33); 
cannot redeclare (file: /etc/puppetlabs/code/environments/master/modules/tools/manifests/ltrace.pp, line: 7) 
(file: /etc/puppetlabs/code/environments/master/modules/tools/manifests/ltrace.pp, line: 7, column: 3)
```